### PR TITLE
Allow use on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,10 @@ and `team_name` variables at the top of the script.
 *The script does not yet check if you have already posted a summary for the
 given days: if you run the script several times, summaries will be posted
 several times! PR welcome :-)*
+
+Dependencies
+------------
+For OS X users, please install `coreutilities` to be able to use GNU `date`.
+```
+homebrew install coreutilities
+```

--- a/git-done
+++ b/git-done
@@ -83,6 +83,17 @@ fi
 
 startdate="$@"
 
+if [[ $OSTYPE == darwin* ]]; then
+    ##check if gdate available (standard date command on unix doesn't allow 'yesterday' etc.)
+    command -v gdate >/dev/null 2>&1 
+    if [ $? != 0 ]; then
+        echo "Please install gdate from coreutils" >&2
+        exit -1
+    fi
+    alias date=gdate
+    shopt -s expand_aliases
+fi
+
 d=$(date -I -d "$startdate") || exit -1
 enddate=$(date -I)
 


### PR DESCRIPTION
unix date command is quite different (and awkward), so rather than make it work with that I found it easier to just continue using GNU date (gdate)
