### PR TITLE
Error fixes for unconfigured repos

### DIFF
--- a/git-done
+++ b/git-done
@@ -94,7 +94,7 @@ while [ "$d" != "$enddate" ]; do
     for line in $(find $HOME -name ".git" -type d);do
         path=$(dirname $line)
         cd $path
-        nbcommit=$(git shortlog -s -n --author="$(git config user.name)" --all --since="$d 00:00" --until="$d 23:59" | awk '{print $1}')
+        nbcommit=$(git shortlog HEAD -s -n --author="$(git config user.name)" --all --since="$d 00:00" --until="$d 23:59" | awk '{print $1}')
 
 
         if [ ! -z $nbcommit ]

--- a/git-done
+++ b/git-done
@@ -94,8 +94,7 @@ while [ "$d" != "$enddate" ]; do
     for line in $(find $HOME -name ".git" -type d);do
         path=$(dirname $line)
         cd $path
-        nbcommit=$(git shortlog HEAD -s -n --author="$(git config user.name)" --all --since="$d 00:00" --until="$d 23:59" | awk '{print $1}')
-
+        nbcommit=$(git shortlog HEAD -s -n --author="$(git config user.name)" --all --since="$d 00:00" --until="$d 23:59" 2>&1 | awk '/[0-9]+/ {print $1}')
 
         if [ ! -z $nbcommit ]
         then


### PR DESCRIPTION
Some of my repositories weren't playing well with git shortlog e.g. poorly configured ones with no 'origin'
